### PR TITLE
swev-id: psf__requests-1142 drop empty GET Content-Length

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -386,6 +386,11 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.body = body
 
     def prepare_content_length(self, body):
+        if body is None and self.method in ('GET', 'HEAD'):
+            if 'Content-Length' in self.headers:
+                del self.headers['Content-Length']
+            return
+
         self.headers['Content-Length'] = '0'
         if hasattr(body, 'seek') and hasattr(body, 'tell'):
             body.seek(0, 2)

--- a/test_requests.py
+++ b/test_requests.py
@@ -280,5 +280,65 @@ class RequestsTestCase(unittest.TestCase):
         self.assertEqual(r.links['next']['rel'], 'next')
 
 
+class PreparedRequestContentLengthTests(unittest.TestCase):
+
+    url = 'http://example.com/'
+
+    def prepare(self, method, **kwargs):
+        req = requests.Request(method=method, url=self.url, **kwargs)
+        return req.prepare()
+
+    def test_no_content_length_on_get_without_body(self):
+        prep = self.prepare('GET')
+        self.assertNotIn('Content-Length', prep.headers)
+
+    def test_no_content_length_on_head_without_body(self):
+        prep = self.prepare('HEAD')
+        self.assertNotIn('Content-Length', prep.headers)
+
+    def test_content_length_on_get_with_body(self):
+        body = 'payload'
+        prep = self.prepare('GET', data=body)
+        self.assertEqual(prep.headers['Content-Length'], str(len(body)))
+
+    def test_chunked_on_stream_without_length(self):
+        class Stream(object):
+            def __init__(self):
+                self._emitted = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._emitted:
+                    raise StopIteration
+                self._emitted = True
+                return 'chunk'
+
+            def next(self):  # pragma: no cover -- Py2 compatibility
+                return self.__next__()
+
+            def __len__(self):
+                raise TypeError()
+
+        prep = self.prepare('POST', data=Stream())
+        self.assertEqual(prep.headers['Transfer-Encoding'], 'chunked')
+        self.assertNotIn('Content-Length', prep.headers)
+
+    def test_post_keeps_zero_content_length_when_no_body(self):
+        prep = self.prepare('POST')
+        self.assertEqual(prep.headers['Content-Length'], '0')
+
+    def test_redirect_post_to_get_drops_content_length(self):
+        post_prep = self.prepare('POST')
+        self.assertEqual(post_prep.headers['Content-Length'], '0')
+
+        redirect_headers = dict(post_prep.headers)
+        redirect_req = requests.Request('GET', self.url, headers=redirect_headers)
+        redirect_prep = redirect_req.prepare()
+
+        self.assertNotIn('Content-Length', redirect_prep.headers)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- skip setting `Content-Length` for GET/HEAD requests with no body
- add unit coverage for GET/HEAD, streamed uploads, redirects, and POST defaults

## Issue
- Fixes #4

## Reproduction
```python
import requests
req = requests.Request('GET', 'http://example.com')
prep = req.prepare()
print(prep.headers['Content-Length'])  # 0 before this change
```

## Pre-fix failure
```text
..FF.F
======================================================================
FAIL: test_no_content_length_on_get_without_body (test_requests.PreparedRequestContentLengthTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/requests/test_requests.py", line 293, in test_no_content_length_on_get_without_body
    self.assertNotIn('Content-Length', prep.headers)
AssertionError: 'Content-Length' unexpectedly found in {'Content-Length': '0'}

======================================================================
FAIL: test_no_content_length_on_head_without_body (test_requests.PreparedRequestContentLengthTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/requests/test_requests.py", line 297, in test_no_content_length_on_head_without_body
    self.assertNotIn('Content-Length', prep.headers)
AssertionError: 'Content-Length' unexpectedly found in {'Content-Length': '0'}

======================================================================
FAIL: test_redirect_post_to_get_drops_content_length (test_requests.PreparedRequestContentLengthTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/requests/test_requests.py", line 340, in test_redirect_post_to_get_drops_content_length
    self.assertNotIn('Content-Length', redirect_prep.headers)
AssertionError: 'Content-Length' unexpectedly found in {'Content-Length': '0'}

----------------------------------------------------------------------
Ran 6 tests in 0.003s

FAILED (failures=3)
```

## Tests
```bash
python3 - <<'PY'
import collections
import collections.abc
collections.MutableMapping = collections.abc.MutableMapping
import unittest
suite = unittest.defaultTestLoader.loadTestsFromName('test_requests.PreparedRequestContentLengthTests')
result = unittest.TextTestRunner().run(suite)
exit(not result.wasSuccessful())
PY
```
