### PR TITLE
fix: swev-id: psf__requests-1921 omit None session headers

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -391,7 +391,11 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         """Prepares the given HTTP headers."""
 
         if headers:
-            self.headers = CaseInsensitiveDict((to_native_string(name), value) for name, value in headers.items())
+            self.headers = CaseInsensitiveDict(
+                (to_native_string(name), value)
+                for name, value in headers.items()
+                if value is not None
+            )
         else:
             self.headers = CaseInsensitiveDict()
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -384,8 +384,10 @@ class RequestsTestCase(unittest.TestCase):
     def test_conflicting_post_params(self):
         url = httpbin('post')
         with open('requirements.txt') as f:
-            pytest.raises(ValueError, "requests.post(url, data='[{\"some\": \"data\"}]', files={'some': f})")
-            pytest.raises(ValueError, "requests.post(url, data=u'[{\"some\": \"data\"}]', files={'some': f})")
+            with pytest.raises(ValueError):
+                requests.post(url, data='[{"some": "data"}]', files={'some': f})
+            with pytest.raises(ValueError):
+                requests.post(url, data=u'[{"some": "data"}]', files={'some': f})
 
     def test_request_ok_set(self):
         r = requests.get(httpbin('status', '404'))
@@ -803,6 +805,20 @@ class RequestsTestCase(unittest.TestCase):
         s.headers['foo'] = 'bar'
         r = s.get(httpbin('get'), headers={'FOO': None})
         assert 'foo' not in r.request.headers
+
+    def test_session_default_header_none_omits_accept_encoding(self):
+        s = requests.Session()
+        assert 'Accept-Encoding' in s.headers
+        s.headers['Accept-Encoding'] = None
+        r = s.get(httpbin('get'))
+        assert 'Accept-Encoding' not in r.request.headers
+
+    def test_session_default_header_remove_is_case_insensitive(self):
+        s = requests.Session()
+        assert 'Accept-Encoding' in s.headers
+        s.headers['ACCEPT-ENCODING'] = None
+        r = s.get(httpbin('get'))
+        assert 'Accept-Encoding' not in r.request.headers
 
     def test_params_are_merged_case_sensitive(self):
         s = requests.Session()


### PR DESCRIPTION
Fixes #8

## Observed Failure & Reproduction
- Starting from `psf__requests-1921`, set a session default header to `None`.
- The prepared request still contains `Accept-Encoding: None`, so servers receive the literal string `"None"`.

```python
import requests
s = requests.Session()
s.headers['Accept-Encoding'] = None
r = s.get('http://httpbin.org/get')
print(r.request.headers['Accept-Encoding'])  # -> 'None' prior to this fix
```

## Stack Trace
No stack trace is emitted—the regression presents as the incorrect header value.

## Fix
- Skip headers whose values are `None` when building `PreparedRequest.headers`.
- Add regression coverage ensuring session defaults set to `None` omit `Accept-Encoding` in a case-insensitive manner.
- Modernize an existing `pytest.raises` assertion so the suite runs under contemporary pytest.

## Testing
- ```
  .venv/bin/python - <<'PY'
  import collections
  import collections.abc
  collections.MutableMapping = collections.abc.MutableMapping
  collections.Mapping = collections.abc.Mapping
  collections.Callable = collections.abc.Callable
  import pytest
  raise SystemExit(pytest.main())
  PY
  ```
  (120 passed, 0 failed)