### PR TITLE
Py2.7: normalize method to native str to avoid UnicodeDecodeError (swev-id: psf__requests-1724)

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -308,6 +308,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.method = method
         if self.method is not None:
             self.method = self.method.upper()
+            self.method = to_native_string(self.method)
 
     def prepare_url(self, url, params):
         """Prepares the given HTTP URL."""

--- a/test_requests.py
+++ b/test_requests.py
@@ -13,7 +13,7 @@ import requests
 import pytest
 from requests.auth import HTTPDigestAuth
 from requests.adapters import HTTPAdapter
-from requests.compat import str, cookielib, getproxies, urljoin, urlparse
+from requests.compat import str, bytes, is_py2, cookielib, getproxies, urljoin, urlparse
 from requests.cookies import cookiejar_from_dict
 from requests.exceptions import InvalidURL, MissingSchema
 from requests.structures import CaseInsensitiveDict
@@ -677,6 +677,47 @@ class RequestsTestCase(unittest.TestCase):
         p = req.prepare()
 
         assert p.headers['Content-Length'] == length
+
+    def test_unicode_method_request_with_files(self):
+        url = httpbin('post')
+        files = {'upload': ('test.txt', 'payload')}
+
+        response = requests.request(method=u'POST', url=url, files=files)
+
+        assert response.status_code == 200
+        assert response.request.method == 'POST'
+
+    def test_session_request_unicode_method_and_post(self):
+        session = requests.Session()
+        url = httpbin('post')
+        files = {'upload': ('test.txt', 'payload')}
+
+        unicode_method_response = session.request(method=u'POST', url=url, files=files)
+        assert unicode_method_response.status_code == 200
+        assert unicode_method_response.request.method == 'POST'
+
+        post_response = session.post(url, files={'upload': ('test.txt', 'payload')})
+        assert post_response.status_code == 200
+        assert post_response.request.method == 'POST'
+
+    def test_unicode_method_allows_non_ascii_paths(self):
+        url = httpbin(u'anything', u'ø')
+
+        response = requests.request(method=u'POST', url=url, data={'value': '1'})
+
+        assert response.status_code == 200
+        assert response.request.method == 'POST'
+
+    def test_prepared_request_method_is_native_str(self):
+        request = requests.Request(method=u'POST', url=httpbin('post'))
+        prepared = request.prepare()
+
+        if is_py2:
+            assert isinstance(prepared.method, bytes)
+        else:
+            assert isinstance(prepared.method, str)
+
+        assert prepared.method == 'POST'
 
 class TestContentEncodingDetection(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- coerce `PreparedRequest.method` to `to_native_string` after uppercasing so unicode inputs become native bytes on Py2
- add regression coverage for unicode methods across request/session flows, non-ASCII paths, and type expectations on Py2 vs Py3

## Reproduction (Py2.7)
```python
import requests
files = {'file': ('bin.dat', b'\xff\xfe\xfd\x00binary')}
requests.request(method=u"POST", url="http://httpbin.org/post", files=files)
```

## Observed Failure (before fix)
```
Traceback (most recent call last):
  File "test_requests.py", line 6, in <module>
    response = requests.request(method=u'POST', url=u'http://httpbin.org/post', files=files)
  File "requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "requests/sessions.py", line 335, in request
    resp = self.send(prep, **send_kwargs)
  File "requests/sessions.py", line 438, in send
    r = adapter.send(request, **kwargs)
  File "requests/adapters.py", line 292, in send
    timeout=timeout
  File "requests/packages/urllib3/connectionpool.py", line 428, in urlopen
    body=body, headers=headers)
  File "requests/packages/urllib3/connectionpool.py", line 280, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "httplib.py", line 955, in request
    self._send_request(method, url, body, headers)
  File "httplib.py", line 989, in _send_request
    self.endheaders(body)
  File "httplib.py", line 951, in endheaders
    self._send_output(message_body)
  File "httplib.py", line 809, in _send_output
    msg += message_body
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcf in position 140: ordinal not in range(128)
```

## Test Plan
- [x] Py2.7:
  ```bash
  source .venv-py2/bin/activate
  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py.test test_requests.py
  ```
- [x] Py3.10 (targeted regression cases with compatibility shims for legacy collections API):
  ```bash
  source .venv-py3/bin/activate
  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='--assert=plain' python - <<'PY'
import collections
import collections.abc
for name in ("Mapping", "MutableMapping", "MutableSet", "MutableSequence", "Callable"):
    if not hasattr(collections, name):
        setattr(collections, name, getattr(collections.abc, name))
import pytest
pytest.main([
    "test_requests.py::RequestsTestCase::test_unicode_method_request_with_files",
    "test_requests.py::RequestsTestCase::test_session_request_unicode_method_and_post",
    "test_requests.py::RequestsTestCase::test_unicode_method_allows_non_ascii_paths",
    "test_requests.py::RequestsTestCase::test_prepared_request_method_is_native_str",
])
PY
  ```

Resolves #5