### PR TITLE
Normalize bytes methods in session swev-id: psf__requests-2317

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -13,7 +13,7 @@ from collections import Mapping
 from datetime import datetime
 
 from .auth import _basic_auth_str
-from .compat import cookielib, OrderedDict, urljoin, urlparse, builtin_str
+from .compat import cookielib, OrderedDict, urljoin, urlparse
 from .cookies import (
     cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar, merge_cookies)
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -360,9 +360,14 @@ class Session(SessionRedirectMixin):
         if self.trust_env and not auth and not self.auth:
             auth = get_netrc_auth(request.url)
 
+        prepared_method = request.method
+        if prepared_method is not None:
+            prepared_method = to_native_string(prepared_method)
+            prepared_method = prepared_method.upper()
+
         p = PreparedRequest()
         p.prepare(
-            method=request.method.upper(),
+            method=prepared_method,
             url=request.url,
             files=request.files,
             data=request.data,
@@ -425,7 +430,7 @@ class Session(SessionRedirectMixin):
             If Tuple, ('cert', 'key') pair.
         """
 
-        method = builtin_str(method)
+        method = to_native_string(method)
 
         # Create the Request.
         req = Request(

--- a/test_requests.py
+++ b/test_requests.py
@@ -21,7 +21,7 @@ from requests.cookies import cookiejar_from_dict, morsel_to_cookie
 from requests.exceptions import (ConnectionError, ConnectTimeout,
                                  InvalidSchema, InvalidURL, MissingSchema,
                                  ReadTimeout, Timeout)
-from requests.models import PreparedRequest
+from requests.models import PreparedRequest, Response
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin
 from requests.models import urlencode
@@ -596,6 +596,83 @@ class RequestsTestCase(unittest.TestCase):
         s = requests.Session()
         prep = s.prepare_request(req)
         assert prep.url == "https://httpbin.org/"
+
+    def test_session_request_normalizes_bytes_method(self):
+        class RecordingAdapter(HTTPAdapter):
+            def __init__(self):
+                super(RecordingAdapter, self).__init__()
+                self.last_method = None
+
+            def send(self, request, *args, **kwargs):
+                self.last_method = request.method
+                response = Response()
+                response.status_code = 200
+                response._content = b''
+                response.url = request.url
+                response.request = request
+                return response
+
+        adapter = RecordingAdapter()
+        s = requests.Session()
+        s.mount('http://', adapter)
+
+        s.request(method=b'GET', url='http://example.com/bytes')
+
+        assert adapter.last_method == 'GET'
+        assert isinstance(adapter.last_method, builtin_str)
+
+    def test_session_prepare_request_normalizes_bytes_method(self):
+        s = requests.Session()
+        req = requests.Request(method=b'GET', url='http://example.com/')
+
+        prep = s.prepare_request(req)
+
+        assert prep.method == 'GET'
+        assert isinstance(prep.method, builtin_str)
+
+    def test_redirect_with_bytes_method(self):
+        class DummyRaw(object):
+            def read(self, *args, **kwargs):
+                return b''
+
+            def close(self):
+                pass
+
+            def release_conn(self):
+                pass
+
+        class RedirectAdapter(HTTPAdapter):
+            def __init__(self):
+                super(RedirectAdapter, self).__init__()
+                self.methods = []
+
+            def send(self, request, *args, **kwargs):
+                self.methods.append(request.method)
+                response = Response()
+                response.status_code = 301 if len(self.methods) == 1 else 200
+                response._content = b''
+                response.url = request.url
+                response.request = request
+                response.raw = DummyRaw()
+                response.headers = CaseInsensitiveDict()
+                if len(self.methods) == 1:
+                    response.headers['location'] = 'http://example.com/final'
+                return response
+
+        adapter = RedirectAdapter()
+        s = requests.Session()
+        s.max_redirects = 2
+        s.mount('http://', adapter)
+
+        response = s.request(
+            method=b'POST',
+            url='http://example.com/start',
+            allow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert adapter.methods == ['POST', 'GET']
+        assert isinstance(adapter.methods[1], builtin_str)
 
     def test_links(self):
         r = requests.Response()


### PR DESCRIPTION
## Summary
- replace `builtin_str` with `to_native_string` when normalizing request methods in `Session.request`
- ensure `Session.prepare_request` uppercases a native string method before preparing
- add adapter-based regression tests covering bytes methods for requests, prepares, and redirects

## Reproduction
1. Ensure Python 3.10 is available (e.g. `nix profile install nixpkgs#python310`).
2. Alias legacy `collections` symbols before importing `requests`:
   ```python
   import collections, collections.abc
   collections.Mapping = collections.abc.Mapping
   collections.MutableMapping = collections.abc.MutableMapping
   collections.Callable = collections.abc.Callable
   ```
3. Run the capture script from the issue:
   ```python
   from requests.sessions import Session
   from requests.adapters import HTTPAdapter

   class CapturingAdapter(HTTPAdapter):
       def send(self, request, *args, **kwargs):
           assert request.method == 'GET', f"Bad method: {request.method!r}"
           from requests.models import Response
           r = Response()
           r.status_code = 200
           r.url = request.url
           r.request = request
           return r

   s = Session()
   s.mount('http://', CapturingAdapter())
   s.request(method=b'GET', url='http://example.com/')
   ```

### Observed failure (pre-fix)
```
Traceback (most recent call last):
  File "<stdin>", line 22, in <module>
  File "requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "<stdin>", line 12, in send
AssertionError: Bad method: "B'GET'"
```

## Testing
- `PYTHONPATH=$HOME/.nix-profile/lib/python3.10/site-packages:/nix/store/p39jr3xhyq0xxd6mn0klw6j4m0b0lnr6-python3.10-pytest-8.4.2/lib/python3.10/site-packages:/nix/store/skxxnb250jm90dhwiw7a60c0hc5nd3rc-python3.10-pluggy-1.6.0/lib/python3.10/site-packages:/nix/store/7k1vwi32yka6yr9n1i3rmks0fnaqsk2a-python3.10-packaging-25.0/lib/python3.10/site-packages:/nix/store/8j87bjfdbpgybz0h7qhhpnqgcscnk0f7-python3.10-iniconfig-2.1.0/lib/python3.10/site-packages:/nix/store/dc4djsgvlx1y5fnsrnkgzjkiw0qkwlkm-python3.10-exceptiongroup-1.3.0/lib/python3.10/site-packages:/nix/store/0fbxkcsir5clfnldn3qhlmzjjvr6f24p-python3.10-tomli-2.2.1/lib/python3.10/site-packages:/nix/store/wnmpyrgwsz2bdwph2askwhh1drv9hd48-python3.10-typing-extensions-4.15.0/lib/python3.10/site-packages:/nix/store/k4zlqqzb5aki8kydjqxqck3ksj997ayk-python3.10-pygments-2.19.2/lib/python3.10/site-packages \
  python3 - <<'PY'
import collections, collections.abc
collections.Mapping = collections.abc.Mapping
collections.MutableMapping = collections.abc.MutableMapping
collections.Callable = collections.abc.Callable

import unittest
import test_requests

suite = unittest.TestSuite()
for test_name in (
    'test_session_request_normalizes_bytes_method',
    'test_session_prepare_request_normalizes_bytes_method',
    'test_redirect_with_bytes_method',
):
    suite.addTest(test_requests.RequestsTestCase(test_name))

result = unittest.TextTestRunner().run(suite)
if not result.wasSuccessful():
    raise SystemExit(1)
PY
- `python3 -m py_compile requests/sessions.py test_requests.py`

Fixes #13.