### PR TITLE
swev-id: psf__requests-6028 - Fix proxy authorization handshake regression

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -409,10 +409,48 @@ class HTTPAdapter(BaseAdapter):
         :rtype: requests.Response
         """
 
+        proxy = select_proxy(request.url, proxies)
+        proxy_authorization = request.headers.get('Proxy-Authorization')
+        proxy_manager = None
+        original_proxy_manager_headers = None
+        updated_proxy_headers = None
+        tunnel_proxy_headers = None
+        proxy_conn = None
+        _MISSING = object()
+        original_conn_proxy_headers = _MISSING
+
+        if proxy and proxy_authorization:
+            proxy = prepend_scheme_if_needed(proxy, 'http')
+            proxy_url = parse_url(proxy)
+            proxy_scheme = proxy_url.scheme.lower() if proxy_url.scheme else ''
+
+            if not proxy_scheme.startswith('socks'):
+                # Ungated to keep CONNECT auth consistent after CPython 3.8.12
+                # changes (Issue #16).
+                proxy_manager = self.proxy_manager_for(proxy)
+                original_proxy_manager_headers = getattr(proxy_manager, 'proxy_headers', None)
+
+                if original_proxy_manager_headers is None:
+                    updated_proxy_headers = {}
+                else:
+                    updated_proxy_headers = original_proxy_manager_headers.copy()
+
+                updated_proxy_headers['Proxy-Authorization'] = proxy_authorization
+                proxy_manager.proxy_headers = updated_proxy_headers
+                tunnel_proxy_headers = updated_proxy_headers
+
         try:
             conn = self.get_connection(request.url, proxies)
         except LocationValueError as e:
+            if proxy_manager and updated_proxy_headers is not None:
+                proxy_manager.proxy_headers = original_proxy_manager_headers
             raise InvalidURL(e, request=request)
+
+        proxy_conn = conn
+
+        if tunnel_proxy_headers and hasattr(proxy_conn, 'proxy_headers'):
+            original_conn_proxy_headers = getattr(proxy_conn, 'proxy_headers', _MISSING)
+            proxy_conn.proxy_headers = tunnel_proxy_headers
 
         self.cert_verify(conn, request.url, verify, cert)
         url = self.request_url(request, proxies)
@@ -534,5 +572,18 @@ class HTTPAdapter(BaseAdapter):
                 raise InvalidHeader(e, request=request)
             else:
                 raise
+
+        finally:
+            if updated_proxy_headers is not None and proxy_manager is not None:
+                if proxy_conn is not None and hasattr(proxy_conn, 'proxy_headers'):
+                    if original_conn_proxy_headers is _MISSING:
+                        try:
+                            del proxy_conn.proxy_headers
+                        except AttributeError:
+                            proxy_conn.proxy_headers = None
+                    else:
+                        proxy_conn.proxy_headers = original_conn_proxy_headers
+
+                proxy_manager.proxy_headers = original_proxy_manager_headers
 
         return self.build_response(request, resp)

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -293,8 +293,8 @@ class SessionRedirectMixin(object):
         except KeyError:
             username, password = None, None
 
-        if username and password:
-            headers['Proxy-Authorization'] = _basic_auth_str(username, password)
+        if username is not None:
+            headers['Proxy-Authorization'] = _basic_auth_str(username, password or '')
 
         return new_proxies
 

--- a/tests/test_proxy_connect_auth.py
+++ b/tests/test_proxy_connect_auth.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+import select
+import socket
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+from requests.auth import HTTPProxyAuth, _basic_auth_str
+from requests.exceptions import ProxyError
+
+from .testserver.server import Server
+
+
+def _read_connect_request(sock):
+    data = b''
+    sock.settimeout(5)
+
+    while b'\r\n\r\n' not in data:
+        chunk = sock.recv(65535)
+        if not chunk:
+            break
+        data += chunk
+
+    return data
+
+
+def _parse_header_lines(header_bytes):
+    header_text = header_bytes.decode('latin1')
+    lines = header_text.split('\r\n')[1:]
+    headers = {}
+
+    for line in lines:
+        if not line:
+            break
+        if ':' not in line:
+            continue
+        name, value = line.split(':', 1)
+        headers[name.strip().lower()] = value.strip()
+
+    return headers, header_text
+
+
+def _pipe_between(client_sock, upstream_sock):
+    sockets = [client_sock, upstream_sock]
+    idle_cycles = 0
+
+    while True:
+        ready, _, _ = select.select(sockets, [], [], 0.2)
+        if not ready:
+            idle_cycles += 1
+            if idle_cycles > 25:
+                break
+            continue
+
+        idle_cycles = 0
+
+        if client_sock in ready:
+            chunk = client_sock.recv(65535)
+            if not chunk:
+                break
+            upstream_sock.sendall(chunk)
+
+        if upstream_sock in ready:
+            chunk = upstream_sock.recv(65535)
+            if not chunk:
+                break
+            client_sock.sendall(chunk)
+
+
+def _proxy_handler(target_host, target_port, expected_auth, log):
+    def handler(sock):
+        request_bytes = _read_connect_request(sock)
+        headers, header_text = _parse_header_lines(request_bytes)
+        log.append(header_text)
+
+        received_auth = headers.get('proxy-authorization')
+        if received_auth != expected_auth:
+            response = (
+                'HTTP/1.1 407 Proxy Authentication Required\r\n'
+                'Proxy-Authenticate: Basic realm="proxy"\r\n'
+                'Content-Length: 0\r\n'
+                'Connection: close\r\n'
+                '\r\n'
+            )
+            sock.sendall(response.encode('latin1'))
+            return header_text
+
+        upstream = socket.create_connection((target_host, target_port))
+
+        try:
+            sock.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+            _pipe_between(sock, upstream)
+        finally:
+            upstream.close()
+
+        return header_text
+
+    return handler
+
+
+@pytest.mark.skipif(not hasattr(socket, 'create_connection'), reason='socket unavailable')
+def test_proxy_connect_407_without_header_then_ok_with_header(httpbin_secure):
+    target_url = httpbin_secure('get')
+    parsed_target = urlparse(target_url)
+    expected_auth = _basic_auth_str('user', 'pass')
+    connect_log = []
+
+    handler = _proxy_handler(parsed_target.hostname, parsed_target.port or 443, expected_auth, connect_log)
+
+    with Server(handler=handler, host='127.0.0.1', port=0, requests_to_handle=3) as (proxy_host, proxy_port):
+        proxies = {'https': 'http://{}:{}'.format(proxy_host, proxy_port)}
+        session = requests.Session()
+        session.trust_env = False
+        session.proxies.update(proxies)
+
+        with pytest.raises(ProxyError) as first_error:
+            session.get(target_url, timeout=5, verify=False)
+
+        assert '407' in str(first_error.value)
+
+        response = session.get(
+            target_url,
+            timeout=5,
+            verify=False,
+            auth=HTTPProxyAuth('user', 'pass')
+        )
+
+        assert response.status_code == 200
+
+        with pytest.raises(ProxyError) as third_error:
+            session.get(target_url, timeout=5, verify=False)
+
+        assert '407' in str(third_error.value)
+
+    assert len(connect_log) >= 3
+    first_connect = connect_log[0].lower()
+    second_connect = connect_log[1].lower()
+    third_connect = connect_log[2].lower()
+
+    assert 'proxy-authorization' not in first_connect
+    assert 'proxy-authorization' in second_connect
+    assert 'proxy-authorization' not in third_connect

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -14,8 +14,9 @@ import re
 import io
 import requests
 import pytest
+from types import MethodType
 from requests.adapters import HTTPAdapter
-from requests.auth import HTTPDigestAuth, _basic_auth_str
+from requests.auth import HTTPDigestAuth, HTTPProxyAuth, _basic_auth_str
 from requests.compat import (
     Morsel, cookielib, getproxies, str, urlparse,
     builtin_str)
@@ -34,6 +35,7 @@ from requests.compat import MutableMapping
 
 from .compat import StringIO, u
 from .utils import override_environ
+from urllib3.response import HTTPResponse
 from urllib3.util import Timeout as Urllib3Timeout
 
 # Requests to this URL should always fail with a connection timeout (nothing
@@ -600,6 +602,94 @@ class TestRequests:
         sent_headers = resp.json().get('headers', {})
 
         assert sent_headers.get("Proxy-Authorization") == proxy_auth_value
+
+    def test_https_connect_uses_request_proxy_authorization_header(self, monkeypatch):
+        adapter = HTTPAdapter()
+        session = requests.Session()
+        session.trust_env = False
+        session.mount('https://', adapter)
+
+        proxies = {'https': 'http://proxy.local:8080'}
+        expected_auth = _basic_auth_str('user', 'pass')
+
+        proxy_headers_snapshots = []
+
+        class DummyConnection(object):
+            def __init__(self, manager):
+                self.manager = manager
+
+            def urlopen(self, method=None, url=None, body=None, headers=None, **kwargs):
+                proxy_headers = self.manager.proxy_headers
+                if proxy_headers is None:
+                    proxy_headers_snapshots.append(None)
+                else:
+                    proxy_headers_snapshots.append(proxy_headers.copy())
+
+                return HTTPResponse(
+                    status=200,
+                    headers={},
+                    body=b'',
+                    preload_content=True
+                )
+
+        class DummyProxyManager(object):
+            def __init__(self):
+                self.proxy_headers = {'Existing': 'value'}
+
+            def connection_from_url(self, url):
+                return DummyConnection(self)
+
+            def clear(self):
+                pass
+
+        proxy_manager = DummyProxyManager()
+        original_headers = proxy_manager.proxy_headers
+
+        def fake_proxy_manager_for(this, proxy, **proxy_kwargs):
+            return proxy_manager
+
+        monkeypatch.setattr(
+            adapter,
+            'proxy_manager_for',
+            MethodType(fake_proxy_manager_for, adapter)
+        )
+
+        request = requests.Request(
+            'GET',
+            'https://example.com',
+            auth=HTTPProxyAuth('user', 'pass')
+        )
+        prepared = session.prepare_request(request)
+
+        response = session.send(prepared, proxies=proxies, verify=False, stream=True)
+        response.close()
+
+        assert len(proxy_headers_snapshots) == 1
+        first_snapshot = proxy_headers_snapshots[0]
+        assert first_snapshot is not None
+        assert first_snapshot['Proxy-Authorization'] == expected_auth
+        assert first_snapshot['Existing'] == 'value'
+
+        assert proxy_manager.proxy_headers is original_headers
+        assert 'Proxy-Authorization' not in proxy_manager.proxy_headers
+
+        request_without_auth = requests.Request('GET', 'https://example.com')
+        prepared_without_auth = session.prepare_request(request_without_auth)
+
+        second_response = session.send(
+            prepared_without_auth,
+            proxies=proxies,
+            verify=False,
+            stream=True
+        )
+        second_response.close()
+
+        assert len(proxy_headers_snapshots) == 2
+        second_snapshot = proxy_headers_snapshots[1]
+        assert second_snapshot is not None
+        assert 'Proxy-Authorization' not in second_snapshot
+        assert proxy_manager.proxy_headers is original_headers
+        assert 'Proxy-Authorization' not in proxy_manager.proxy_headers
 
     def test_basicauth_with_netrc(self, httpbin):
         auth = ('user', 'pass')
@@ -1895,6 +1985,20 @@ class TestRequests:
         adapter = HTTPAdapter()
         headers = adapter.proxy_headers("http://user:@httpbin.org")
         assert headers == {'Proxy-Authorization': 'Basic dXNlcjo='}
+
+    def test_rebuild_proxies_keeps_proxy_auth_with_empty_password(self):
+        session = requests.Session()
+        session.trust_env = False
+
+        request = requests.Request('GET', 'http://example.com/')
+        prepared = session.prepare_request(request)
+        prepared.headers['Proxy-Authorization'] = 'to-be-cleared'
+
+        proxies = {'http': 'http://user:@proxy.local'}
+
+        session.rebuild_proxies(prepared, proxies)
+
+        assert prepared.headers['Proxy-Authorization'] == _basic_auth_str('user', '')
 
     def test_response_json_when_content_is_None(self, httpbin):
         r = requests.get(httpbin('/status/204'))


### PR DESCRIPTION
Issue: https://github.com/agyn-sandbox/requests/issues/16

## Root Cause
- CPython 3.8.12 changed how CONNECT tunnels reuse urllib3 proxy managers, so the per-request `Proxy-Authorization` header set by `PreparedRequest` never reached the CONNECT handshake.
- `Session.rebuild_proxies` dropped proxy credentials when the password was empty, so requests with blank passwords lost authentication on redirect or rebuild.

## Reproduction
1. Checkout `psf__requests-6028`.
2. Create a Python 3.8.12 virtualenv (urllib3==1.26.7) and install dev requirements.
3. Run:
   - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 LD_LIBRARY_PATH=$HOME/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib pytest -p pytest_mock -p pytest_httpbin.plugin tests/test_requests.py::TestRequests::test_https_connect_uses_request_proxy_authorization_header`
   - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 LD_LIBRARY_PATH=$HOME/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib pytest -p pytest_mock -p pytest_httpbin.plugin tests/test_requests.py::TestRequests::test_rebuild_proxies_keeps_proxy_auth_with_empty_password`
   - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 LD_LIBRARY_PATH=$HOME/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib pytest -p pytest_mock -p pytest_httpbin.plugin tests/test_proxy_connect_auth.py::test_proxy_connect_407_without_header_then_ok_with_header`
4. Observe failures such as:
   ```text
   OSError: Tunnel connection failed: 407 Proxy Authentication Required
   urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(... Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 407 Proxy Authentication Required')))
   ```

## Changes
- Propagate the current request's `Proxy-Authorization` header onto the urllib3 `ProxyManager` used for CONNECT tunnels (non-SOCKS only) and ensure the tunnel connection inherits the header.
- Retain proxy credentials with empty passwords when rebuilding proxies by always emitting `_basic_auth_str(username, password or '')` when a username is supplied.
- Add regression coverage for CONNECT proxy auth propagation and the empty-password rebuild scenario.

## Testing (Python 3.8.12)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 LD_LIBRARY_PATH=$HOME/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib pytest -p pytest_mock -p pytest_httpbin.plugin` (562 passed, 12 skipped, 1 xfailed)
- `flake8 --select=E9,F63,F7,F82 requests/adapters.py requests/sessions.py tests/test_requests.py tests/test_proxy_connect_auth.py`

## CI
- Not run per instructions.
